### PR TITLE
Remove configuration to copy micro-gw.conf since it is overridden by configmap

### DIFF
--- a/conf/deployment-config.toml
+++ b/conf/deployment-config.toml
@@ -5,9 +5,3 @@
 	registry = 'index.docker.io/wso2'
         tag = 'v1'
         baseImage = 'wso2/wso2micro-gw:3.0.1'
-    [docker.dockerCopyFiles]
-        enable = true
-        [[docker.dockerCopyFiles.files]]
-            source = '$MICROGW_TOOLKIT_HOME/resources/conf/micro-gw.conf'
-            target = '/home/ballerina/conf/micro-gw.conf'
-            isBallerinaConf = true


### PR DESCRIPTION
## Purpose
In the microgateway helm chart, a configmap is used for the micro-gw.conf. Therefore copying the default configuration from the toolkit is unnecessary since this would be replaced by the said config map in the pod.